### PR TITLE
GRPC Protocol Update for Inference Parameter Types

### DIFF
--- a/specification/protocol/open_inference_grpc.proto
+++ b/specification/protocol/open_inference_grpc.proto
@@ -274,6 +274,12 @@ message InferParameter
 
     // A string parameter value.
     string string_param = 3;
+
+    // A double parameter value.
+    double double_param = 4;
+
+    // A uint64 parameter value.
+    uint64 uint64_param = 5;
   }
 }
 


### PR DESCRIPTION
Added support for double and uint64 inference parameter types.

Example motivation was to support 64-bit request priority.