### PR TITLE
Adding Properties field to Model Metadata Response

### DIFF
--- a/specification/protocol/open_inference_grpc.proto
+++ b/specification/protocol/open_inference_grpc.proto
@@ -130,6 +130,9 @@ message ModelMetadataResponse
 
   // The model's outputs.
   repeated TensorMetadata outputs = 5;
+
+  // Optional Model Properties
+  map<string, string> properties = 6;
 }
 
 message ModelInferRequest

--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -183,6 +183,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/metadata_tensor'
+        properties:
+          type: object
+          additionalProperties:
+            type: string
       required:
         - name
         - platform


### PR DESCRIPTION
Allow arbitrary properties to be added to model metadata.

Motivation is to allow additional descriptive fields such as model card metadata to be returned.

Field is optional.